### PR TITLE
Check all queues at once to reduce idle time

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -19,7 +19,7 @@ struct Params {
 //
 // Command to see a worker randomly check queues based on their weight:
 //
-// RUST_LOG=debug cargo run --example main -- -q a:1 -q b:2 -q c:3 -c 1   
+// RUST_LOG=debug cargo run --example main -- -q a:1 -q b:2 -q c:3 -c 1
 //
 
 fn main() {


### PR DESCRIPTION
Additionally, increase Redis timeout from 2 seconds to 10 seconds so workers don't sit idle after processing very short jobs. We can't block indefinitely (like the Ruby version does) without a larger refactor, since the event loop has other responsibilities.

Resolves #3