### PR TITLE
Add option to pause job processing

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -192,7 +192,7 @@ impl<'a, D> JMapExt<'a, D> for JMap<String, JValue>
     fn remove_datetime(&mut self, key: &str) -> Result<DateTime<Utc>, D::Error> {
         self.remove(key)
             .and_then(|v| v.as_f64())
-            .map(|f| NaiveDateTime::from_timestamp(f as i64, ((f - f.floor()) * 1e9) as u32))
+            .and_then(|f| NaiveDateTime::from_timestamp_opt(f as i64, ((f - f.floor()) * 1e9) as u32))
             .map(|t| DateTime::from_utc(t, Utc))
             .ok_or(D::Error::custom(format!("no member '{}'", key)))
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,6 +50,7 @@ pub struct SidekiqServer<'a> {
     concurrency: usize,
     pub queue_shuffle: bool,
     pub force_quite_timeout: usize,
+    pub pause_if: Option<fn() -> bool>,
 }
 
 impl<'a> SidekiqServer<'a> {
@@ -78,6 +79,7 @@ impl<'a> SidekiqServer<'a> {
             signal_chan,
             queue_shuffle: true,
             force_quite_timeout: 10,
+            pause_if: None,
             middlewares: vec![],
             rs: String::from_utf8_lossy(&identity).to_string(),
         })
@@ -180,7 +182,8 @@ impl<'a> SidekiqServer<'a> {
                                             .map(|(k, v)| (k.clone(), v.cloned()))
                                             .collect(),
                                         self.middlewares.iter_mut().map(|v| v.cloned()).collect(),
-                                        self.namespace.clone());
+                                        self.namespace.clone(),
+                                        self.pause_if);
         self.worker_info.insert(worker.id.clone(), false);
         self.threadpool.execute(move || worker.work());
     }


### PR DESCRIPTION
This PR adds an optional callback that can be used to pause all Sidekiq processes, e.g., when the application is in read-only mode. It's intended to use some global state (e.g. in Redis) to determine if jobs should be processed. This is preferable over sending a signal to each worker, because it's respected even by new ephemeral workers.

```rs
server.pause_if = Some(read_only::active);
```

~~Note: #11 needs to be reviewed and merged before this.~~