### PR TITLE
Add ability to perform concurrency-limited work

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -46,6 +46,7 @@ fn main() {
     for (name, weight) in queues {
         server.new_queue(&name, weight);
     }
+    server.new_queue_limited("limited", 1, 1);
 
     server.namespace = params.namespace;
     server.force_quite_timeout = params.timeout;


### PR DESCRIPTION
This lets you register a certain Sidekiq queue to have a limited number of threads assigned to it, that way expensive jobs aren't at risk of running out of memory if a lot of them are enqueued at once.